### PR TITLE
Make a RedisSpider compatible with a new version of scrapy

### DIFF
--- a/scrapy_redis/spiders.py
+++ b/scrapy_redis/spiders.py
@@ -49,6 +49,6 @@ class RedisMixin(object):
 class RedisSpider(RedisMixin, Spider):
     """Spider that reads urls from redis queue when idle."""
 
-    def set_crawler(self, crawler):
-        super(RedisSpider, self).set_crawler(crawler)
+    def _set_crawler(self, crawler):
+        super(RedisSpider, self)._set_crawler(crawler)
         self.setup_redis()


### PR DESCRIPTION
`set_crawler` is not executed anymore when a spider is created