### PR TITLE
Release 0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ python: 2.7
 services:
   - redis-server
 env:
-  - SCRAPY="scrapy==0.24.6"
+  - SCRAPY="scrapy==1.0.0"
   - SCRAPY="scrapy>=1.0.0"
 install:
   - pip install $SCRAPY
   - pip install -r requirements.txt
   - pip install -r requirements-test.txt
-script: nosetests
+script: py.test

--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,9 @@ Features:
 
 Requirements:
 
-* Scrapy >= 0.24.0
-* redis-py >= 2.8.0
-* redis server >= 2.6.0
+* Scrapy >= 1.0.0
+* redis-py >= 2.10.0
+* redis server >= 2.8.0
 
 Available Scrapy components:
 
@@ -71,11 +71,11 @@ Enable the components in your `settings.py`:
   ITEM_PIPELINES = [
       'scrapy_redis.pipelines.RedisPipeline',
   ]
-  
+
   # Specify the host and port to use when connecting to Redis (optional).
   REDIS_HOST = 'localhost'
   REDIS_PORT = 6379
-  
+
   # Specify the full Redis URL for connecting (optional).
   # If set, this takes precedence over the REDIS_HOST and REDIS_PORT settings.
   REDIS_URL = 'redis://user:pass@hostname:9001'
@@ -154,6 +154,10 @@ Then:
 
 Changelog
 ---------
+
+0.6
+  * Updated code to be compatible with Scrapy 1.0.
+  * Added `-a domain=...` option for example spiders.
 
 0.5
   * Added `REDIS_URL` setting to support Redis connection string.

--- a/example-project/example/items.py
+++ b/example-project/example/items.py
@@ -4,8 +4,9 @@
 # http://doc.scrapy.org/topics/items.html
 
 from scrapy.item import Item, Field
-from scrapy.contrib.loader import ItemLoader
-from scrapy.contrib.loader.processor import MapCompose, TakeFirst, Join
+from scrapy.loader import ItemLoader
+from scrapy.loader.processors import MapCompose, TakeFirst, Join
+
 
 class ExampleItem(Item):
     name = Field()

--- a/example-project/example/spiders/dmoz.py
+++ b/example-project/example/spiders/dmoz.py
@@ -1,17 +1,21 @@
+from scrapy.linkextractors import LinkExtractor
 from scrapy.selector import Selector
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor
-from scrapy.contrib.spiders import CrawlSpider, Rule
+from scrapy.spiders import CrawlSpider, Rule
+
 from example.items import ExampleLoader
+
 
 class DmozSpider(CrawlSpider):
     name = 'dmoz'
     allowed_domains = ['dmoz.org']
     start_urls = ['http://www.dmoz.org/']
 
+    categories_lx = LinkExtractor(restrict_xpaths='//div[@id="catalogs"]')
+    directory_lx = LinkExtractor(restrict_xpaths='//ul[@class="directory dir-col"]')
+
     rules = (
-        Rule(SgmlLinkExtractor(restrict_xpaths='//div[@id="catalogs"]')),
-        Rule(SgmlLinkExtractor(restrict_xpaths='//ul[@class="directory dir-col"]'),
-             callback='parse_directory', follow=True)
+        Rule(categories_lx),
+        Rule(directory_lx, callback='parse_directory', follow=True)
     )
 
     def parse_directory(self, response):

--- a/example-project/example/spiders/dmoz.py
+++ b/example-project/example/spiders/dmoz.py
@@ -1,5 +1,4 @@
 from scrapy.linkextractors import LinkExtractor
-from scrapy.selector import Selector
 from scrapy.spiders import CrawlSpider, Rule
 
 from example.items import ExampleLoader
@@ -19,11 +18,10 @@ class DmozSpider(CrawlSpider):
     )
 
     def parse_directory(self, response):
-        hxs = Selector(response)
-        for li in hxs.xpath('//ul[@class="directory-url"]/li'):
+        for li in response.css('ul.directory-url > li'):
             el = ExampleLoader(selector=li)
-            el.add_xpath('name', 'a/text()')
-            el.add_xpath('description', 'text()')
-            el.add_xpath('link', 'a/@href')
+            el.add_css('name', 'a::text')
+            el.add_css('description', '::text')
+            el.add_css('link', 'a::attr(href)')
             el.add_value('url', response.url)
             yield el.load_item()

--- a/example-project/example/spiders/mycrawler_redis.py
+++ b/example-project/example/spiders/mycrawler_redis.py
@@ -16,6 +16,11 @@ class MyCrawler(RedisMixin, CrawlSpider):
         Rule(LinkExtractor(), callback='parse_page', follow=True),
     )
 
+    def __init__(self, *args, **kwargs):
+        domain = kwargs.pop('domain', '')
+        self.alowed_domains = filter(None, domain.split(','))
+        super(MyCrawler, self).__init__(*args, **kwargs)
+
     def _set_crawler(self, crawler):
         CrawlSpider._set_crawler(self, crawler)
         RedisMixin.setup_redis(self)

--- a/example-project/example/spiders/mycrawler_redis.py
+++ b/example-project/example/spiders/mycrawler_redis.py
@@ -1,7 +1,7 @@
-from scrapy_redis.spiders import RedisMixin
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor
 
-from scrapy.contrib.spiders import CrawlSpider, Rule
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor
+from scrapy_redis.spiders import RedisMixin
 
 from example.items import ExampleLoader
 
@@ -13,7 +13,7 @@ class MyCrawler(RedisMixin, CrawlSpider):
 
     rules = (
         # follow all links
-        Rule(SgmlLinkExtractor(), callback='parse_page', follow=True),
+        Rule(LinkExtractor(), callback='parse_page', follow=True),
     )
 
     def set_crawler(self, crawler):

--- a/example-project/example/spiders/mycrawler_redis.py
+++ b/example-project/example/spiders/mycrawler_redis.py
@@ -16,8 +16,8 @@ class MyCrawler(RedisMixin, CrawlSpider):
         Rule(LinkExtractor(), callback='parse_page', follow=True),
     )
 
-    def set_crawler(self, crawler):
-        CrawlSpider.set_crawler(self, crawler)
+    def _set_crawler(self, crawler):
+        CrawlSpider._set_crawler(self, crawler)
         RedisMixin.setup_redis(self)
 
     def parse_page(self, response):

--- a/example-project/example/spiders/myspider_redis.py
+++ b/example-project/example/spiders/myspider_redis.py
@@ -1,4 +1,5 @@
 from scrapy_redis.spiders import RedisSpider
+
 from example.items import ExampleLoader
 
 

--- a/example-project/example/spiders/myspider_redis.py
+++ b/example-project/example/spiders/myspider_redis.py
@@ -8,6 +8,11 @@ class MySpider(RedisSpider):
     name = 'myspider_redis'
     redis_key = 'myspider:start_urls'
 
+    def __init__(self, *args, **kwargs):
+        domain = kwargs.pop('domain', '')
+        self.alowed_domains = filter(None, domain.split(','))
+        super(MySpider, self).__init__(*args, **kwargs)
+
     def parse(self, response):
         el = ExampleLoader(response=response)
         el.add_xpath('name', '//title[1]/text()')

--- a/scrapy_redis/dupefilter.py
+++ b/scrapy_redis/dupefilter.py
@@ -1,8 +1,9 @@
 import time
-import connection
 
-from scrapy.dupefilter import BaseDupeFilter
+from scrapy.dupefilters import BaseDupeFilter
 from scrapy.utils.request import request_fingerprint
+
+from . import connection
 
 
 class RFPDupeFilter(BaseDupeFilter):

--- a/scrapy_redis/pipelines.py
+++ b/scrapy_redis/pipelines.py
@@ -1,8 +1,7 @@
-import redis
-import connection
-
-from twisted.internet.threads import deferToThread
 from scrapy.utils.serialize import ScrapyJSONEncoder
+from twisted.internet.threads import deferToThread
+
+from . import connection
 
 
 class RedisPipeline(object):

--- a/scrapy_redis/scheduler.py
+++ b/scrapy_redis/scheduler.py
@@ -1,7 +1,7 @@
-import connection
-
 from scrapy.utils.misc import load_object
-from scrapy_redis.dupefilter import RFPDupeFilter
+
+from . import connection
+from .dupefilter import RFPDupeFilter
 
 
 # default values

--- a/scrapy_redis/spiders.py
+++ b/scrapy_redis/spiders.py
@@ -1,8 +1,7 @@
-import connection
-
-from scrapy import signals
+from scrapy import Spider, signals
 from scrapy.exceptions import DontCloseSpider
-from scrapy.spider import Spider
+
+from . import connection
 
 
 class RedisMixin(object):

--- a/scrapy_redis/tests.py
+++ b/scrapy_redis/tests.py
@@ -3,8 +3,7 @@ import os
 import mock
 import redis
 
-from scrapy.http import Request
-from scrapy.spider import Spider
+from scrapy import Request, Spider
 from unittest import TestCase
 
 from . import connection

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ LONG_DESC = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
 
 
 setup(name='scrapy-redis',
-      version='0.5.3',
+      version='0.6.0',
       description='Redis-based components for Scrapy',
       long_description=LONG_DESC,
       author='Rolando Espinoza La fuente',
@@ -14,7 +14,7 @@ setup(name='scrapy-redis',
       url='http://github.com/darkrho/scrapy-redis',
       packages=['scrapy_redis'],
       license='BSD',
-      install_requires=['Scrapy>=0.24.0', 'redis>=2.8.0'],
+      install_requires=['Scrapy>=1.0.0', 'redis>=2.10.0'],
       classifiers=[
           'Programming Language :: Python',
           'Development Status :: 4 - Beta',


### PR DESCRIPTION
This changes makes `scrapy-redis` compatible only with Scrapy 1.0.